### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/mberg-kokoro-tts-mcp-badge.png)](https://mseep.ai/app/mberg-kokoro-tts-mcp)
 
+<a href="https://glama.ai/mcp/servers/@mberg/kokoro-tts-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mberg/kokoro-tts-mcp/badge" alt="Kokoro Text to Speech Server MCP server" />
+</a>
+
 ## Kokoro Text to Speech (TTS) MCP Server
 
 Kokoro Text to Speech MCP server that generates .mp3 files with option to upload to S3.
@@ -136,4 +140,3 @@ The TTS server generates MP3 files that are stored locally and optionally upload
 - Enable/disable S3 uploads with `S3_ENABLED=true` or `DISABLE_S3=true`
 - Configure AWS credentials and bucket settings in the `.env` file
 - S3 uploads can be disabled per-request using the client's `--no-s3` option
-


### PR DESCRIPTION
This PR adds a badge for the [Kokoro Text to Speech MCP Server](https://glama.ai/mcp/servers/@mberg/kokoro-tts-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@mberg/kokoro-tts-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mberg/kokoro-tts-mcp/badge" alt="Kokoro Text to Speech Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.